### PR TITLE
Makefile: ensure `make export` works from a fresh checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ zip=passhashplus-${version}.zip
 
 export:
 	rm -f ${zip}
+	mkdir -p archive
 	zip archive/${zip} -r * --exclude archive/*
 
 ff_webext: clean


### PR DESCRIPTION
The archive/ directory needs to be available else `make` will fail.