### PR TITLE
Add option to hide the mask button

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -34,6 +34,7 @@
  * ***** END LICENSE BLOCK ***** */
 var debug = false;
 var maskKey;
+var showMaskButton;
 
 var id = 0;
 
@@ -91,7 +92,7 @@ function bind (f) {
         field.id = "passhash_" + id++;
     }
 
-    if (-1 != fields.indexOf(field) || field.classList.contains("nopasshash")) {
+    if (!showMaskButton || -1 != fields.indexOf(field) || field.classList.contains("nopasshash")) {
         return false;
     }
     fields[fields.length] = field;
@@ -166,12 +167,17 @@ browser.storage.local.get('sync').then(results => {
     var area = results.sync ? browser.storage.sync : browser.storage.local;
     area.get('options').then(optres => {
         maskKey = optres.options.maskKey;
+        showMaskButton = optres.options.showMaskButton;
     });
 });
 // Register for storage changes to update maskkey when necessary
 browser.storage.onChanged.addListener(function (changes, areaName) {
     if ('options' in changes) {
         maskKey = changes.options.newValue.maskKey;
+        if (showMaskButton !== changes.options.newValue.showMaskButton) {
+            showMaskButton = changes.options.newValue.showMaskButton;
+            initAllFields();
+        }
         if (debug) console.log("[passwordhasherplus] mask key changed from " + changes.options.oldValue.maskKey + " to " + maskKey);
     }
 });

--- a/options.html
+++ b/options.html
@@ -145,6 +145,14 @@
 			</td>
 		</tr>
 		<tr>
+			<td class="label">Show Mask Button</td>
+			<td>
+				<div class="browser-style">
+				<input id="maskbutton" type="checkbox"/><label for="maskbutton">Show the mask button next to password fields.</label>
+				</div>
+			</td>
+		</tr>
+		<tr>
 			<td class="label">Private Key:</td>
 			<td>
 				<div class="browser-style">

--- a/options.js
+++ b/options.js
@@ -39,6 +39,7 @@ function saveOptions () {
 	} else {
 		delete options.custom;
 	}
+	options.showMaskButton = document.getElementById ("maskbutton").checked;
 	options.compatibilityMode = document.getElementById ("compatibility").checked;
 	options.privateSeed = document.getElementById ("seed").value;
 	options.backedUp = document.getElementById ("backedup").checked;
@@ -53,6 +54,7 @@ function restoreOptions () {
         document.getElementById ("length").value = options.defaultLength;
         document.getElementById ("strength").value = options.defaultStrength;
         document.getElementById ("compatibility").checked = options.compatibilityMode;
+        document.getElementById ("maskbutton").checked = options.showMaskButton;
         document.getElementById ("seed").value = options.privateSeed;
         document.getElementById ("backedup").checked = options.backedUp;
         document.getElementById ("hashkey").value = options.hashKey;

--- a/storage.js
+++ b/storage.js
@@ -90,6 +90,10 @@ Storage.prototype.loadOptions = function () {
 		options.compatibilityMode = false;
 		dirty = true;
 	}
+	if (null == options.showMaskButton) {
+		options.showMaskButton = true;
+		dirty = true;
+	}
 	if (null == options.hashKey) {
 		options.hashKey = default_hashkey;
 		dirty = true;


### PR DESCRIPTION
This PR adds a new option, defaulting to true, to show the mask button next to password fields. I've tried to follow the coding style as closely as possible whenever evident.

One thing that's still a little weird is that when going from mask enabled to mask disabled, the mask buttons are not removed. I'm not sure how valuable such a feature is, since refreshing the page removes the field as well.

If there's anything I should change about this, I'll get on it ASAP.