### PR TITLE
Improve content-script robustness

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -32,7 +32,7 @@
  * the terms of any one of the MPL, the GPL or the LGPL.
  *
  * ***** END LICENSE BLOCK ***** */
-var debug = false;
+var debug = true;
 var maskKey;
 var showMaskButton;
 
@@ -149,9 +149,6 @@ function initAllFields() {
     }
 }
 
-// run on initial page content
-initAllFields();
-
 // Make sure we react to dynamically appearing elements
 function onMutation (mutations, observer) {
     mutations.forEach (function(mutation) {
@@ -166,7 +163,6 @@ function onMutation (mutations, observer) {
     });
 }
 var observer = new MutationObserver (onMutation);
-observer.observe (document, { childList: true, subtree: true });
 
 // Grab options from storage
 browser.storage.local.get('sync').then(results => {
@@ -174,6 +170,12 @@ browser.storage.local.get('sync').then(results => {
     area.get('options').then(optres => {
         maskKey = optres.options.maskKey;
         showMaskButton = optres.options.showMaskButton;
+        if (debug) console.log("Got settings: maskKey="+maskKey+", showMaskButton="+showMaskButton);
+        // run on initial page content after we've gotten settings
+        initAllFields();
+        // only start observing document for changes when we've gotten
+        // settings from storage
+        observer.observe (document, { childList: true, subtree: true });
     });
 });
 // Register for storage changes to update maskkey when necessary
@@ -182,8 +184,11 @@ browser.storage.onChanged.addListener(function (changes, areaName) {
         maskKey = changes.options.newValue.maskKey;
         if (showMaskButton !== changes.options.newValue.showMaskButton) {
             showMaskButton = changes.options.newValue.showMaskButton;
+            if (debug) console.log("[passwordhasherplus] showMaskButton changed: " + showMaskButton);
             initAllFields();
         }
-        if (debug) console.log("[passwordhasherplus] mask key changed from " + changes.options.oldValue.maskKey + " to " + maskKey);
+        if (maskKey !== changes.options.oldValue.maskKey) {
+            if (debug) console.log("[passwordhasherplus] mask key changed from " + changes.options.oldValue.maskKey + " to " + maskKey);
+        }
     }
 });

--- a/content-script.js
+++ b/content-script.js
@@ -92,14 +92,18 @@ function bind (f) {
         field.id = "passhash_" + id++;
     }
 
-    if (!showMaskButton || -1 != fields.indexOf(field) || field.classList.contains("nopasshash")) {
+    if (-1 != fields.indexOf(field) || field.classList.contains("nopasshash")) {
         return false;
     }
     fields[fields.length] = field;
 
     var masking = true;
 
-    var maskbutton = createMaskButton(field);
+    var maskbutton = null;
+    if (showMaskButton) {
+        // Only create button when `showMaskButton` is true
+        maskbutton = createMaskButton(field);
+    }
 
     /* toggle masking... maybe remove here? */
     function setFieldType () {
@@ -123,7 +127,9 @@ function bind (f) {
     }
 
     /* make button do something */
-    maskbutton.addEventListener('click', toggleMasking);
+    if (maskbutton != null) {
+        maskbutton.addEventListener('click', toggleMasking);
+    }
     /* bind shortcut also */
     field.addEventListener('keydown', function (e) {
         var shortcut = (e.ctrlKey ? "Ctrl+" : "") + (e.shiftKey ? "Shift+" : "") + e.which;


### PR DESCRIPTION
A regression in #23 was missed due to incomplete testing.  This commit restores the ability to use the configured mask/unmask shortcut (`Ctrl+Shift+8` by default) when the extension is configured to not show the mask button.